### PR TITLE
Moved sudo from phase 4 to phase 3.

### DIFF
--- a/cucumber/meta/phase3/packages
+++ b/cucumber/meta/phase3/packages
@@ -32,3 +32,7 @@ libksba
 npth
 gnupg
 
+# Build sudo. Portmake depends on sudo in order for privilege separation to
+# work.
+sudo
+

--- a/cucumber/meta/phase4/packages
+++ b/cucumber/meta/phase4/packages
@@ -14,7 +14,6 @@ htop
 sl
 lzip
 ed
-sudo
 cpio
 lm_sensors
 p7zip


### PR DESCRIPTION
Portmake depends on sudo in order for privilege separation to work.