### PR TITLE
sl: fixed buildinfo bug

### DIFF
--- a/cucumber/apps/sl/sl.buildinfo
+++ b/cucumber/apps/sl/sl.buildinfo
@@ -29,7 +29,7 @@ BUILDDEPS=()
 
 build () {
 
-	tar -xf "$OWD/$NAME-$VERSION.tar.gz" || exit 1
+	tar -xf "$OWD/$VERSION.tar.gz" || exit 1
 	cd $NAME-$VERSION || exit 1
 
 	# Apply any patches located in $OWD/patches


### PR DESCRIPTION
Fixed a bug in sl.buildinfo where it would attempt to extract the sources from
a tarball with an incorrect name.