### PR TITLE
Update portstrap

### DIFF
--- a/utilities/tools/portstrap
+++ b/utilities/tools/portstrap
@@ -25,7 +25,7 @@ ROOT=${ROOT:-}
 PORTSDIR="$ROOT/usr/ports"
 
 # The default location to clone the ports tree from.
-PORTSURL='https://gitlab.cucumberlinux.com/cucumber/ports.git'
+PORTSURL='https://github.com/cucumberlinux/ports.git'
 
 # The default branch (version) of the ports tree to fetch.
 PORTSBRANCH='master'

--- a/utilities/tools/portstrap
+++ b/utilities/tools/portstrap
@@ -30,9 +30,11 @@ PORTSURL='https://github.com/cucumberlinux/ports.git'
 # The default branch (version) of the ports tree to fetch.
 PORTSBRANCH='master'
 
-# The user who can write to the ports tree. Default to the first unprivileged
-# user, or root if there is no unprivileged user.
-PORTSUSER=$(id -nu 1000)
+# The user who can write to the ports tree. Defaults to the "portuser" user if
+# he exists, then to the first unprivileged user and finally to  root if there
+# is no unprivileged user.
+id portuser && PORTSUSER=portuser
+PORTSUSER=${PORTSUSER:-$(id -nu 1000)}
 PORTSUSER=${PORTSUSER:-root}
 
 if [ $(id -u) -ne 0 ]; then


### PR DESCRIPTION
Portstrap now uses GitHub instead of GitLab when cloning the repository again. It also now defaults to using the portuser as the privilege separation user if he exists.