### PR TITLE
linux: upgraded to 4.14.111

### DIFF
--- a/cucumber/base/linux/linux.buildinfo
+++ b/cucumber/base/linux/linux.buildinfo
@@ -23,7 +23,7 @@
 # Cucumber Linux Buildinfo for linux
 
 NAME=linux
-VERSION=4.14.110
+VERSION=4.14.111
 URL=(	https://cdn.kernel.org/pub/$NAME/kernel/v4.x/$NAME-$VERSION.tar.xz
 	https://cdn.kernel.org/pub/$NAME/kernel/v4.x/$NAME-$VERSION.tar.sign)
 BUILDDEPS=()

--- a/utilities/tools/portstrap
+++ b/utilities/tools/portstrap
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2018 Scott Court
+# Copyright 2018, 2019 Scott Court
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -33,7 +33,7 @@ PORTSBRANCH='master'
 # The user who can write to the ports tree. Defaults to the "portuser" user if
 # he exists, then to the first unprivileged user and finally to  root if there
 # is no unprivileged user.
-id portuser && PORTSUSER=portuser
+id portuser > /dev/null && PORTSUSER=portuser
 PORTSUSER=${PORTSUSER:-$(id -nu 1000)}
 PORTSUSER=${PORTSUSER:-root}
 


### PR DESCRIPTION
This is an upstream bug fix release that also likely contains security
fixes. For more information see:
	https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.14.111