### PR TITLE
lzo: enabled building of shared libraries

### DIFF
--- a/cucumber/lib/lzo/lzo.buildinfo
+++ b/cucumber/lib/lzo/lzo.buildinfo
@@ -41,6 +41,7 @@ build () {
 		--libdir=/usr/lib${LIBDIRSUFFIX} \
 		--sysconfdir=/etc \
 		--localstatedir=/var \
+		--enable-shared \
 		--disable-static \
 		--build=$CUCARCH-cucumber-linux || exit 1
 	pkgapi_make || exit 1


### PR DESCRIPTION
Also disabled the building of the static lzo library.

Fixes #90 